### PR TITLE
fix(SUP-26215): hotspot is unclickable when mobile skin is used

### DIFF
--- a/packages/plugin-v2/CHANGELOG.md
+++ b/packages/plugin-v2/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 0.5.2 (2021-04-25)
-
-### Fix
-
-* v2: mobile Adnroid - hotspot is unclickable when mobile skin is used
 
 ## 0.5.1 (2019-03-31)
 

--- a/packages/plugin-v2/CHANGELOG.md
+++ b/packages/plugin-v2/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.5.2 (2021-04-25)
+
+### Fix
+
+* v2: mobile Adnroid - hotspot is unclickable when mobile skin is used
 
 ## 0.5.1 (2019-03-31)
 

--- a/packages/plugin-v2/src/plugin.tsx
+++ b/packages/plugin-v2/src/plugin.tsx
@@ -253,7 +253,7 @@ import { convertToHotspots } from "@plugin/shared/cuepoints";
                                 top: 0,
                                 left: 0,
                                 overflow: "visible",
-                                "z-index": "2"
+                                zIndex: 2
                             });
                     }
 

--- a/packages/plugin-v2/src/plugin.tsx
+++ b/packages/plugin-v2/src/plugin.tsx
@@ -252,7 +252,8 @@ import { convertToHotspots } from "@plugin/shared/cuepoints";
                                 width: "0",
                                 top: 0,
                                 left: 0,
-                                overflow: "visible"
+                                overflow: "visible",
+                                "z-index": "2"
                             });
                     }
 


### PR DESCRIPTION
The issue:
when mobile skin is enabled and playing entries in Android (mobile devices), hotspots needs to be clicked twice in order to work.

The solution:
make hotspots layout's z-index higher than ui layout's.

Solves [SUP-26215](https://kaltura.atlassian.net/browse/SUP-26215)