### PR TITLE
fix(FEV-1506): Inside playlist the hotspot from the first played entry that includes them is being duplicated when moving to the other entries (link time and url are available).

### DIFF
--- a/src/hotspots-plugin.tsx
+++ b/src/hotspots-plugin.tsx
@@ -195,6 +195,8 @@ export class HotspotsPlugin extends KalturaPlayer.core.BasePlugin {
 
   reset(): void {
     this.eventManager.removeAll();
+    this._hotspots = [];
+    this._canvas = null;
     if (this._floatingItem) {
       this._contribServices.floatingManager.remove(this._floatingItem);
       this._floatingItem = null;


### PR DESCRIPTION
clean hotspots data on reset;