### PR TITLE
fix(FEV-1526): The hotspots will remain on the screen if the user seeks forward past the end point in the timeline

### DIFF
--- a/src/hotspots-plugin.tsx
+++ b/src/hotspots-plugin.tsx
@@ -133,7 +133,8 @@ export class HotspotsPlugin extends KalturaPlayer.core.BasePlugin {
 
   private _onTimedMetadataChange = ({payload}: TimedMetadataEvent) => {
     const hotspotCues = this._filterHotspotCues(payload.cues);
-    if (hotspotCues.length) {
+    // update HotspotsContainer to add or remove visible hotspots
+    if (hotspotCues.length || this._hotspots.length) {
       const rawLayoutHotspots = this._prepareHotspots(hotspotCues);
       this._hotspots = this._recalculateCuepointLayout(rawLayoutHotspots);
       this._updateHotspotsContainer();


### PR DESCRIPTION
1) update hotspots layout if hotspot cues got active (add new hotspots);
2) update hotspots layout if active hotspot cues absent but plugin has visible hotspots (remove hotspots);