### PR TITLE
Add `z-index` to hotspot div

### DIFF
--- a/src/components/Hotspot.tsx
+++ b/src/components/Hotspot.tsx
@@ -11,6 +11,7 @@ const defaultContainerStyles = {
 
 const defaultButtonsStyles = {
   position: 'relative',
+  z-index: 2,
   width: '100%',
   height: '100%',
   appearance: 'none',


### PR DESCRIPTION
When hotspot position is set such that it overlaps that of `<div class="playkit-top-bar">` (say "layout":{"relativeX":0,"relativeY":0}), the element is not clickable.


