### PR TITLE
fix(FEV-1659): hotspots starting from 0.00 are hidden

### DIFF
--- a/src/hotspots-plugin.tsx
+++ b/src/hotspots-plugin.tsx
@@ -144,7 +144,7 @@ export class HotspotsPlugin extends KalturaPlayer.core.BasePlugin {
   private _addHotspotsContainer(): void {
     this._floatingItem = this._contribServices.floatingManager.add({
       label: 'Hotspots',
-      mode: FloatingUIModes.FirstPlay,
+      mode: FloatingUIModes.MediaLoaded,
       position: FloatingPositions.VideoArea,
       renderContent: this._renderRoot
     });


### PR DESCRIPTION
**the issue:**
on preload:auto configuration hotspots with straTime=0 are not displayed on the player

**the solution:** 
change the mode in the floatingManager to MediaLoaded instead of FirstPlay

solves FEV-1659