### PR TITLE
fix(FEC-13348): dynamically adjust hotspot text with player size

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Finally, add the bundle as a script tag in your page, and initialize the player
      ...
      targetId: 'player-placeholder',
      plugins: {
-      hotspots: { ... },
+      "playkit-js-hotspots": { ... },
       kalturaCuepoints: { ... },
      }
      ...

--- a/src/components/Hotspot.tsx
+++ b/src/components/Hotspot.tsx
@@ -152,22 +152,11 @@ export default class Hotspot extends Component<Props, State> {
   };
 
   getFontSize = (layout: any, hotspot: any, label: string): number => {
-    let textEl = document.createElement('div');
-    textEl.id = 'textDivTest';
-    textEl.style.position = 'absolute';
+    let textEl = this.createDivElement();
     textEl.style.top = `${layout.y}px`;
-    textEl.style.appearance = 'none';
-    textEl.style.border = 'none';
-    textEl.style.display = 'table-cell';
-    textEl.style.textAlign = 'center';
-    textEl.style.cursor = 'pointer';
-    textEl.style.wordBreak = 'break-all';
-    textEl.style.textRendering = 'geometricPrecision';
     textEl.style.fontSize = `${hotspot.styles['font-size']}px`;
     textEl.style.fontFamily = `${hotspot.styles['font-family']}`;
-    textEl.style.color = `${hotspot.styles['color']}`;
     textEl.textContent = label || '';
-
     document.body.appendChild(textEl);
 
     const textWidth = textEl.clientWidth;
@@ -186,6 +175,17 @@ export default class Hotspot extends Component<Props, State> {
 
     document.body.removeChild(textEl);
     return fontSizeToUse;
+  }
+
+  createDivElement = (): HTMLDivElement => {
+    let divEl = document.createElement('div');
+    divEl.id = 'textDivTest';
+    divEl.style.position = 'absolute';
+    divEl.style.display = 'table-cell';
+    divEl.style.textAlign = 'center';
+    divEl.style.wordBreak = 'break-all';
+    divEl.style.textRendering = 'geometricPrecision';
+    return divEl;
   }
 
   render() {

--- a/src/components/Hotspot.tsx
+++ b/src/components/Hotspot.tsx
@@ -20,7 +20,10 @@ const defaultButtonsStyles = {
   textAlign: 'center',
   cursor: 'pointer',
   wordBreak: 'break-all',
-  textRendering: 'geometricPrecision'
+  textRendering: 'geometricPrecision',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap'
 };
 
 type Props = {
@@ -148,6 +151,61 @@ export default class Hotspot extends Component<Props, State> {
     }
   };
 
+  getFontSize = (layout: any, hotspot: any, label: string): number => {
+    let container = document.createElement('div');
+    container.id = 'containerDivTest';
+    container.style.top = `${layout.y}px`;
+    container.style.height = `${layout.height}px`;
+    container.style.width = `${layout.width}px`;
+    container.style.position = 'absolute';
+    container.style.display = 'table';
+    container.style.boxSizing = 'border-box';
+
+    let textEl = document.createElement('div');
+    textEl.id = 'textDivTest';
+    textEl.style.position = 'absolute';
+    textEl.style.top = `${layout.y}px`;
+    textEl.style.appearance = 'none';
+    textEl.style.border = 'none';
+    textEl.style.display = 'table-cell';
+    textEl.style.textAlign = 'center';
+    textEl.style.cursor = 'pointer';
+    textEl.style.wordBreak = 'break-all';
+    textEl.style.textRendering = 'geometricPrecision';
+    textEl.style.fontSize = `${hotspot.styles['font-size']}px`;
+    textEl.style.fontFamily = `${hotspot.styles['font-family']}`;
+    textEl.style.color = `${hotspot.styles['color']}`;
+    textEl.textContent = label || '';
+
+    document.body.appendChild(container)
+    document.body.appendChild(textEl);
+
+    const textWidth = textEl.clientWidth;
+    let initialFontSize = parseInt(hotspot.styles['font-size']);
+    let fontSizeToUse = initialFontSize;
+    const MINIMAL_FONT_SIZE = 10;
+    if (textWidth > layout.width) {
+      for (let fontSizeToCheck = initialFontSize - 1; fontSizeToCheck >= MINIMAL_FONT_SIZE; fontSizeToCheck--) {
+        if (fontSizeToCheck === MINIMAL_FONT_SIZE) {
+          // if we reached the minimal font, then use it
+          fontSizeToUse = fontSizeToCheck;
+          break;
+        }
+        textEl.style.fontSize = `${fontSizeToCheck}px`;
+        const newTextWidth = textEl.clientWidth;
+        if (newTextWidth <= layout.width) {
+          fontSizeToUse = fontSizeToCheck;
+          break;
+        }
+      }
+    }
+
+    document.body.removeChild(textEl);
+    document.body.removeChild(container);
+
+    return fontSizeToUse;
+  }
+
   render() {
     const {hotspot} = this.props;
     const {layout, label} = hotspot;
@@ -165,10 +223,14 @@ export default class Hotspot extends Component<Props, State> {
       width: layout.width
     };
 
+    const fontSizeToUse = `${this.getFontSize(layout, hotspot, label || '')}px`;
+
     const buttonStyles = {
       ...defaultButtonsStyles,
       ...hotspot.styles,
-      cursor: disableClick ? 'default' : 'pointer'
+      cursor: disableClick ? 'default' : 'pointer',
+      maxWidth: `${layout.width}px`,
+      fontSize: fontSizeToUse
     };
 
     return (

--- a/src/components/Hotspot.tsx
+++ b/src/components/Hotspot.tsx
@@ -152,15 +152,6 @@ export default class Hotspot extends Component<Props, State> {
   };
 
   getFontSize = (layout: any, hotspot: any, label: string): number => {
-    let container = document.createElement('div');
-    container.id = 'containerDivTest';
-    container.style.top = `${layout.y}px`;
-    container.style.height = `${layout.height}px`;
-    container.style.width = `${layout.width}px`;
-    container.style.position = 'absolute';
-    container.style.display = 'table';
-    container.style.boxSizing = 'border-box';
-
     let textEl = document.createElement('div');
     textEl.id = 'textDivTest';
     textEl.style.position = 'absolute';
@@ -177,7 +168,6 @@ export default class Hotspot extends Component<Props, State> {
     textEl.style.color = `${hotspot.styles['color']}`;
     textEl.textContent = label || '';
 
-    document.body.appendChild(container)
     document.body.appendChild(textEl);
 
     const textWidth = textEl.clientWidth;
@@ -185,24 +175,16 @@ export default class Hotspot extends Component<Props, State> {
     let fontSizeToUse = initialFontSize;
     const MINIMAL_FONT_SIZE = 10;
     if (textWidth > layout.width) {
-      for (let fontSizeToCheck = initialFontSize - 1; fontSizeToCheck >= MINIMAL_FONT_SIZE; fontSizeToCheck--) {
-        if (fontSizeToCheck === MINIMAL_FONT_SIZE) {
-          // if we reached the minimal font, then use it
-          fontSizeToUse = fontSizeToCheck;
-          break;
-        }
-        textEl.style.fontSize = `${fontSizeToCheck}px`;
+      for (fontSizeToUse = initialFontSize - 1; fontSizeToUse >= MINIMAL_FONT_SIZE; fontSizeToUse--) {
+        textEl.style.fontSize = `${fontSizeToUse}px`;
         const newTextWidth = textEl.clientWidth;
         if (newTextWidth <= layout.width) {
-          fontSizeToUse = fontSizeToCheck;
           break;
         }
       }
     }
 
     document.body.removeChild(textEl);
-    document.body.removeChild(container);
-
     return fontSizeToUse;
   }
 

--- a/src/components/Hotspot.tsx
+++ b/src/components/Hotspot.tsx
@@ -51,6 +51,8 @@ function prepareUrl(url: string): string {
   return url;
 }
 
+const MINIMAL_FONT_SIZE = 10;
+
 export default class Hotspot extends Component<Props, State> {
   static defaultProps = defaultProps;
 
@@ -162,7 +164,6 @@ export default class Hotspot extends Component<Props, State> {
     const textWidth = textEl.clientWidth;
     let initialFontSize = parseInt(hotspot.styles['font-size']);
     let fontSizeToUse = initialFontSize;
-    const MINIMAL_FONT_SIZE = 10;
     if (textWidth > layout.width) {
       for (fontSizeToUse = initialFontSize - 1; fontSizeToUse >= MINIMAL_FONT_SIZE; fontSizeToUse--) {
         textEl.style.fontSize = `${fontSizeToUse}px`;


### PR DESCRIPTION
the requirement is to have the hotspot text fit into 1 line.

**solution:**
create a temporary hotspot container div and a temporary hotspot text div with the same styles as the real ones, make calculations to find the ideal font-size to use for the text.

Solves [FEC-13348](https://kaltura.atlassian.net/browse/FEC-13348)

[FEC-13348]: https://kaltura.atlassian.net/browse/FEC-13348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ