### PR TITLE
fix(SUP-43778):v7 Player Hotspot Text Formatting

### DIFF
--- a/src/components/Hotspot.tsx
+++ b/src/components/Hotspot.tsx
@@ -26,6 +26,7 @@ const defaultButtonsStyles = {
   alignItems: 'center',
   justifyContent: 'center',
   outline: 0,
+  lineHeight: 'normal'
 };
 
 type Props = {


### PR DESCRIPTION
issue:
*hotspots didn't break line (in kea it breaks lines)
*when change player size the hotspots text and border radius didn't changed accordingly

fix was provided but qa found in kms the space between lines in hotspots is very small and cause to overlapping

solution:
override kms default line-Hight style

solved [SUP-43778](https://kaltura.atlassian.net/browse/SUP-43778)

[SUP-43778]: https://kaltura.atlassian.net/browse/SUP-43778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ