### PR TITLE
fix(hotspots): retain raw hotspots for re-layout when canvas dimensions are zero (SUP-52841)

### DIFF
--- a/src/hotspots-plugin.tsx
+++ b/src/hotspots-plugin.tsx
@@ -39,6 +39,7 @@ export class HotspotsPlugin extends KalturaPlayer.core.BasePlugin {
 
   private _player: KalturaPlayerTypes.Player;
   private _hotspots: LayoutHotspot[] = [];
+  private _pendingRawHotspots: RawLayoutHotspot[] = [];
   private _floatingItem: FloatingItem | null = null;
   private _canvas: Canvas | null = null;
 
@@ -151,8 +152,8 @@ export class HotspotsPlugin extends KalturaPlayer.core.BasePlugin {
     const hotspotCues = this._filterHotspotCues(payload.cues);
     // update HotspotsContainer to add or remove visible hotspots
     if (hotspotCues.length || this._hotspots.length) {
-      const rawLayoutHotspots = this._prepareHotspots(hotspotCues);
-      this._hotspots = this._recalculateCuepointLayout(rawLayoutHotspots);
+      this._pendingRawHotspots = this._prepareHotspots(hotspotCues);
+      this._hotspots = this._recalculateCuepointLayout(this._pendingRawHotspots);
       this._updateHotspotsContainer();
     }
   };
@@ -203,7 +204,8 @@ export class HotspotsPlugin extends KalturaPlayer.core.BasePlugin {
 
   private _renderRoot = (floatingItemProps: FloatingItemProps): ComponentChildren => {
     if (this._checkIfResizeHappened(floatingItemProps.canvas)) {
-      this._hotspots = this._recalculateCuepointLayout(this._hotspots);
+      const source = this._pendingRawHotspots.length ? this._pendingRawHotspots : this._hotspots;
+      this._hotspots = this._recalculateCuepointLayout(source);
     }
     return (
       <HotspotWrapper  dispatcher={(eventType, payload) => this.dispatchEvent(eventType, payload)} key={'hotspotWrapper'} hotspots={this._hotspots} pauseVideo={this._pauseVideo} seekTo={this._seekTo} sendAnalytics={() => {}} />
@@ -213,6 +215,7 @@ export class HotspotsPlugin extends KalturaPlayer.core.BasePlugin {
   reset(): void {
     this.eventManager.removeAll();
     this._hotspots = [];
+    this._pendingRawHotspots = [];
     this._canvas = null;
     if (this._floatingItem) {
       this.floatingManager.remove(this._floatingItem);


### PR DESCRIPTION
## Problem
On mobile devices, hotspots do not appear at their cue times. They only
appear after the user enters fullscreen. On desktop the behaviour is
correct.

## Root Cause
`getVideoSize()` (from `@playkit-js/common`) returns `{width:0, height:0}`
on mobile before the first decoded frame is available. When
`TIMED_METADATA_CHANGE` fires (e.g. at t=2:30), `_recalculateCuepointLayout`
detects zero video dimensions and returns `[]`. The local variable
`rawLayoutHotspots` is then discarded -- it was never stored anywhere.

Later, when `FloatingManager` receives a resize event with real dimensions
and calls `_renderRoot`, `_checkIfResizeHappened` detects a change and
calls `_recalculateCuepointLayout(this._hotspots)`. But `this._hotspots`
is `[]` (set by the failed TIMED_METADATA_CHANGE call), so hotspots never
appear.

Entering fullscreen triggers another `TIMED_METADATA_CHANGE` with the
same cues AND a resize with valid video dimensions, which is why it
works in fullscreen.

## Fix
Introduce `_pendingRawHotspots: RawLayoutHotspot[]` to hold the
pre-layout cue data independently from `_hotspots`.

- `_onTimedMetadataChange` always saves to `_pendingRawHotspots` before
  calling `_recalculateCuepointLayout`. If layout fails (zero canvas),
  the raw data is preserved.
- `_renderRoot` recalculates from `_pendingRawHotspots` (when non-empty)
  on any resize, so the retry on first real video dimensions succeeds.
- `reset()` clears `_pendingRawHotspots` alongside `_hotspots`.

Desktop behaviour is unchanged: `_recalculateCuepointLayout` succeeds
immediately on the first `TIMED_METADATA_CHANGE`, and `_pendingRawHotspots`
stays in sync so the resize path also works correctly.

## Files Changed
- `src/hotspots-plugin.tsx` (+6 -3)

## Tests
- Build: webpack compiled successfully with zero TypeScript errors
- Full suite: N/A (no Jest/Karma unit tests in this repo; Cypress e2e
  tests require a live player environment)

## Jira
https://kaltura.atlassian.net/browse/SUP-52841